### PR TITLE
Add Dockerfile and deployment docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Use CUDA image with development tools so nvcc is available
+FROM nvidia/cuda:12.4.1-cudnn9-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-dev \
+        build-essential git cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip3 install --upgrade pip && \
+    pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118 && \
+    pip3 install -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Install the package in editable mode
+RUN pip3 install -e .
+
+# Build native extensions
+RUN cd hy3dgen/texgen/custom_rasterizer && \
+    python3 setup.py install && \
+    cd /app
+RUN cd hy3dgen/texgen/differentiable_renderer && \
+    python3 setup.py install && \
+    cd /app
+
+EXPOSE 8080
+
+CMD ["python3", "api_server.py", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -255,17 +255,53 @@ and e.t.c.
 python api_server.py --host 0.0.0.0 --port 8080
 ```
 
+The server expects a valid API key in the `X-API-KEY` header. Set the
+`API_KEY` environment variable before launching the server.
+
 A demo post request for image to 3D without texture.
 
 ```bash
 img_b64_str=$(base64 -i assets/demo.png)
 curl -X POST "http://localhost:8080/generate" \
      -H "Content-Type: application/json" \
+     -H "X-API-KEY: $API_KEY" \
      -d '{
            "image": "'"$img_b64_str"'",
          }' \
      -o test2.glb
 ```
+
+Texturing an existing mesh can be done via the `/texture` endpoint:
+
+```bash
+mesh_b64=$(base64 -i test2.glb)
+curl -X POST "http://localhost:8080/texture" \
+     -H "Content-Type: application/json" \
+     -H "X-API-KEY: $API_KEY" \
+     -d '{
+           "mesh": "'"$mesh_b64"'",
+           "image": "'"$img_b64_str"'"
+         }' \
+     -o textured.glb
+```
+
+### Docker
+
+A Dockerfile is provided for GPU-enabled deployments. Build the image and run:
+
+```bash
+
+docker build -t hunyuan3d-api .
+docker run --gpus all -e API_KEY=$API_KEY -p 8080:8080 hunyuan3d-api
+```
+
+The server will listen on port 8080 inside the container.
+
+### Google Cloud
+
+On Google Cloud Compute Engine, create an instance with an NVIDIA L4 GPU and Ubuntu 22.04.
+Install the latest NVIDIA drivers, clone this repository, then build and run the container as
+shown above. Ensure a firewall rule allows inbound TCP traffic on port 8080.
 
 ### Blender Addon
 

--- a/docs/source/started/api.md
+++ b/docs/source/started/api.md
@@ -1,20 +1,53 @@
 # API
 
-You could launch an API server locally, which you could post web request for Image/Text to 3D, Texturing existing mesh,
-and e.t.c.
+You can launch an API server locally, which accepts web requests for Image/Text to 3D and texturing existing meshes.
 
 ```bash
 python api_server.py --host 0.0.0.0 --port 8080
 ```
 
-A demo post request for image to 3D without texture.
+Set an `API_KEY` environment variable and include it in the `X-API-KEY` header for every request.
+
+A demo post request for image to 3D without texture:
 
 ```bash
 img_b64_str=$(base64 -i assets/demo.png)
 curl -X POST "http://localhost:8080/generate" \
      -H "Content-Type: application/json" \
+     -H "X-API-KEY: $API_KEY" \
      -d '{
-           "image": "'"$img_b64_str"'",
+           "image": "'"$img_b64_str"'"
          }' \
      -o test2.glb
 ```
+
+Texturing an existing mesh can be done via `/texture`:
+
+```bash
+mesh_b64=$(base64 -i test2.glb)
+curl -X POST "http://localhost:8080/texture" \
+     -H "Content-Type: application/json" \
+     -H "X-API-KEY: $API_KEY" \
+     -d '{
+           "mesh": "'"$mesh_b64"'",
+           "image": "'"$img_b64_str"'"
+         }' \
+     -o textured.glb
+```
+
+## Docker
+
+A Dockerfile is provided for GPU-enabled deployments:
+
+```bash
+docker build -t hunyuan3d-api .
+docker run --gpus all -e API_KEY=$API_KEY -p 8080:8080 hunyuan3d-api
+```
+
+The server will listen on port 8080 inside the container.
+
+## Google Cloud
+
+For Google Cloud deployments, create a Compute Engine VM with an NVIDIA L4 GPU and Ubuntu 22.04.
+Install the NVIDIA drivers, clone this repository, and then build and run the Docker image as above.
+Allow incoming TCP connections on port 8080 through the firewall.


### PR DESCRIPTION
## Summary
- fix Dockerfile build step to compile native CUDA extensions in their directories
- add Google Cloud notes for running the container
- split native extension builds into separate RUN steps to avoid merge artifacts
- use CUDA *devel* image so nvcc is available during container builds

## Testing
- `python -m py_compile api_server.py`
- `pytest` *(no tests found)*
- `docker build -t test-hunyuan .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9bed27d8832b8a9e54e4206c86c9