### PR TITLE
fix: use valid CUDA base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use CUDA image with development tools so nvcc is available
-FROM nvidia/cuda:12.4.1-cudnn9-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.0-cudnn9-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- use existing CUDA base image `nvidia/cuda:12.4.0-cudnn9-devel-ubuntu22.04`

## Testing
- `docker pull nvidia/cuda:12.4.0-cudnn9-devel-ubuntu22.04` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository not signed (403 Forbidden))*
- `docker build -t hunyuan3d-api .` *(fails: command not found: docker)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError: invalid decimal literal in api_server.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf88eaa8832bb3d90da2d07928e3